### PR TITLE
Add a try-catch around pretty printing

### DIFF
--- a/src/CodeGeneration/PHPClassWriter.php
+++ b/src/CodeGeneration/PHPClassWriter.php
@@ -21,12 +21,18 @@ final class PHPClassWriter
 
     public function writeClass(string $directory, PHPClassDefinition $classDefinition): string
     {
-        $filename = sprintf('%s/%s.php', $directory, $classDefinition->getName());
+        $filename = sprintf('%s/%s', $directory, $classDefinition->getName());
 
-        file_put_contents(
-            $filename,
-            $this->printer->prettyPrintFile($this->parser->parse($classDefinition->getCode()))
-        );
+        try {
+            $code = $this->printer->prettyPrintFile(
+                $this->parser->parse($classDefinition->getCode()) ?? []
+            );
+        } catch (\RuntimeException $e) {
+            $filename = $filename . 'INVALID';
+            $code = $classDefinition->getCode();
+        }
+
+        file_put_contents("$filename.php", $code);
 
         return $filename;
     }


### PR DESCRIPTION
When pretty printing a file, if it goes wrong, the file will not print.

It can be helpful to inspect the generated code for invalid files for debugging.

This try catch should print files out as `<filename>INVALID.php` so it can be debugged.