### PR TITLE
Update nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "nikic/php-parser": "^5.5"
+        "nikic/php-parser": "^4.19.4 | ^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "nikic/php-parser": "^4.17"
+        "nikic/php-parser": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/src/CodeGeneration/PHPClassWriter.php
+++ b/src/CodeGeneration/PHPClassWriter.php
@@ -15,7 +15,7 @@ final class PHPClassWriter
 
     public function __construct()
     {
-        $this->parser = (new ParserFactory)->create(ParserFactory::ONLY_PHP7);
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
         $this->printer = new CodeFormatter();
     }
 

--- a/src/CodeGeneration/PHPClassWriter.php
+++ b/src/CodeGeneration/PHPClassWriter.php
@@ -15,7 +15,14 @@ final class PHPClassWriter
 
     public function __construct()
     {
-        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
+        if (method_exists(ParserFactory::class, 'createForNewestSupportedVersion')) {
+            $this->parser = (new ParserFactory())
+                ->createForNewestSupportedVersion();
+        } else {
+            $this->parser = (new ParserFactory())
+                ->create(ParserFactory::ONLY_PHP7);
+        }
+
         $this->printer = new CodeFormatter();
     }
 


### PR DESCRIPTION
Changed usage of "ParserFactory::create" to
"ParserFactory::createForNewestSupportedVersion"

This is because the "create" has been removed in favour of three new methods:
- "createForNewestSupportedVersion"
- "createForHostVersion"
- "createForVersion"